### PR TITLE
Support configurable default workspace path

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,6 +106,7 @@ Access these settings in the LM Studio "Plugins" tab:
 - **Sub-Agent Debug Logging:** Toggle detailed sub-agent parsing logs for troubleshooting.
 - **Sub-Agent Auto-Save:** Toggle automatic file saving (Default: On).
 - **Show Full Code Output:** Toggle whether to display the full code in chat or hide it for brevity (files are still saved).
+- **Default Workspace Path:** Set the startup workspace directory used by the plugin.
 - **Safety:** Enable/Disable "Allow Code Execution" for Python/JS/Shell.
 - **Browser Safety:** Browser automation for sub-agents requires all three toggles: `Allow Browser Control` + `Sub-Agent: Allow Web Search` + `Sub-Agent: Allow Browser Control`.
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -59,6 +59,10 @@ export const pluginConfigSchematics = createConfigSchematics()
     displayName: "Embedding Model",
     subtitle: "Model to use for RAG features (default: nomic-ai/nomic-embed-text-v1.5-GGUF)",
   }, "nomic-ai/nomic-embed-text-v1.5-GGUF")
+    .field("defaultWorkspacePath", "string", {
+      displayName: "Default Workspace Path",
+      subtitle: "Optional startup workspace path. Leave empty to use the built-in default workspace directory.",
+    }, "")
     .field("enableMemory", "boolean", {
       displayName: "Enable Memory",
       subtitle: "If enabled, the model can save and recall information from a 'memory.md' file in the workspace.",

--- a/src/promptPreprocessor.ts
+++ b/src/promptPreprocessor.ts
@@ -70,6 +70,7 @@ export async function promptPreprocessor(ctl: PromptPreprocessorController, user
 
   // --- Delegation & Safety Instructions (Every Turn) ---
   const pluginConfig = ctl.getPluginConfig(pluginConfigSchematics);
+  const defaultWorkspacePath = pluginConfig.get("defaultWorkspacePath");
   const frequency = pluginConfig.get("subAgentFrequency");
   const debugMode = pluginConfig.get("enableDebugMode");
 
@@ -95,7 +96,7 @@ export async function promptPreprocessor(ctl: PromptPreprocessorController, user
 
   // --- Sub-Agent Documentation Injection (Startup OR On-Enable) ---
   const enableSecondary = pluginConfig.get("enableSecondaryAgent");
-  const state = await getPersistedState();
+  const state = await getPersistedState(defaultWorkspacePath);
 
   // Reset the injection flag on the first turn of a new conversation
   if (isFirstTurn) {
@@ -129,7 +130,7 @@ export async function promptPreprocessor(ctl: PromptPreprocessorController, user
     let injectionContent = TOOLS_DOCUMENTATION;
 
     try {
-        const { currentWorkingDirectory } = await getPersistedState();
+        const { currentWorkingDirectory } = await getPersistedState(defaultWorkspacePath);
         const startupPath = join(currentWorkingDirectory, "startup.md");
         const startupContent = await readFile(startupPath, "utf-8");
         const filesToRead = startupContent.split('\n').map(f => f.trim()).filter(f => f);
@@ -161,7 +162,7 @@ export async function promptPreprocessor(ctl: PromptPreprocessorController, user
 
   // Update message count and memory
   try {
-    const state = await getPersistedState();
+    const state = await getPersistedState(defaultWorkspacePath);
     state.messageCount++;
     await savePersistedState(state);
 

--- a/src/stateManager.ts
+++ b/src/stateManager.ts
@@ -1,5 +1,5 @@
 import { readFile, writeFile, mkdir } from "fs/promises";
-import { join } from "path";
+import { join, isAbsolute, resolve } from "path";
 import * as os from "os";
 
 const CONFIG_FILE_NAME = ".plugin_state.json";
@@ -12,20 +12,34 @@ export interface PluginState {
   subAgentDocsInjected: boolean;
 }
 
-export async function getPersistedState(): Promise<PluginState> {
+function resolveWorkspaceDirectory(configuredWorkspacePath?: string): string {
+  const raw = (configuredWorkspacePath ?? "").trim();
+  if (!raw) return DEFAULT_DIR;
+
+  // Support Windows-style env vars in config values (e.g. %USERPROFILE%\projects\workspace)
+  const expanded = raw.replace(/%([^%]+)%/g, (_match, varName: string) => process.env[varName] ?? `%${varName}%`);
+  return isAbsolute(expanded) ? expanded : resolve(DEFAULT_DIR, expanded);
+}
+
+export async function getPersistedState(configuredWorkspacePath?: string): Promise<PluginState> {
+  const configuredDirectory = resolveWorkspaceDirectory(configuredWorkspacePath);
+  const useConfiguredDirectory = (configuredWorkspacePath ?? "").trim().length > 0;
+
   try {
     const statePath = join(os.homedir(), ".beledarians-llm-toolbox", CONFIG_FILE_NAME);
     const content = await readFile(statePath, "utf-8");
     const state = JSON.parse(content);
     return {
-      currentWorkingDirectory: state.currentWorkingDirectory ?? DEFAULT_DIR,
+      currentWorkingDirectory: useConfiguredDirectory
+        ? configuredDirectory
+        : state.currentWorkingDirectory ?? configuredDirectory,
       messageCount: state.messageCount ?? 0,
       dontAskToCompress: state.dontAskToCompress ?? false,
       subAgentDocsInjected: state.subAgentDocsInjected ?? false,
     };
   } catch (error) {
     return {
-      currentWorkingDirectory: DEFAULT_DIR,
+      currentWorkingDirectory: configuredDirectory,
       messageCount: 0,
       dontAskToCompress: false,
       subAgentDocsInjected: false,

--- a/src/toolsProvider.ts
+++ b/src/toolsProvider.ts
@@ -119,9 +119,10 @@ let isWorkspaceInitialized = false;
 export const toolsProvider: ToolsProvider = async (ctl) => {
   const client = (ctl as any).client as LMStudioClient;
   const pluginConfig = ctl.getPluginConfig(pluginConfigSchematics);
+  const defaultWorkspacePath = pluginConfig.get("defaultWorkspacePath");
 
   // Load state using shared manager
-  const fullState = await getPersistedState();
+  const fullState = await getPersistedState(defaultWorkspacePath);
   let currentWorkingDirectory = fullState.currentWorkingDirectory;
 
   const allowAllCode = pluginConfig.get("allowAllCode");
@@ -149,6 +150,8 @@ export const toolsProvider: ToolsProvider = async (ctl) => {
   // Ensure the directory exists (idempotent)
   if (!isWorkspaceInitialized) {
     await ensureWorkspaceExists(currentWorkingDirectory);
+    fullState.currentWorkingDirectory = currentWorkingDirectory;
+    await savePersistedState(fullState);
     console.log(`Working directory set to: ${currentWorkingDirectory}`);
     isWorkspaceInitialized = true;
   }


### PR DESCRIPTION
Add a new plugin setting `defaultWorkspacePath` to configure the startup workspace directory. Pass this value through to state management and prompt preprocessing so the plugin can resolve and use a custom workspace on startup. Implement resolveWorkspaceDirectory to expand Windows-style %ENV% vars, treat relative paths as relative to the built-in default, and choose the configured directory when provided. Update getPersistedState to accept the configured path and prefer it (and persist it back when workspace is initialized). Update toolsProvider to load/save state with the configured path and ensure workspace creation. Also update README to document the new setting.