### PR TITLE
feat: add Protected Paths config to block operations on specified drives/paths

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -87,6 +87,12 @@ export const pluginConfigSchematics = createConfigSchematics()
     subtitle: c.allowAllCode.subtitle,
   }, false)
 
+  // ── Safety: Protected Paths ─────────────────────────────────────────────────
+  .field("protectedPaths", "string", {
+    displayName: c.protectedPaths.displayName,
+    subtitle: c.protectedPaths.subtitle,
+  }, "")
+
   // ── Search / Embedding ─────────────────────────────────────────────────────
   .field("searchApiKey", "string", {
     displayName: c.searchApiKey.displayName,

--- a/src/locales/de.ts
+++ b/src/locales/de.ts
@@ -62,6 +62,10 @@ export const de: LocaleDict = {
       displayName: "Alle Codeausführung erlauben",
       subtitle: "HAUPTSCHALTER: Überschreibt alle anderen Einstellungen und aktiviert ALLE Ausführungstools.",
     },
+    protectedPaths: {
+      displayName: "Geschützte Pfade",
+      subtitle: "Liste der Laufwerke oder Pfade, für die alle Vorgänge blockiert werden sollen (z. B. D:\\, C:\\Windows). Eine pro Zeile.",
+    },
     searchApiKey: {
       displayName: "Such-API-Schlüssel",
       subtitle: "Optionaler API-Schlüssel für Suchdienste zur Vermeidung von Rate-Limits.",

--- a/src/locales/en.ts
+++ b/src/locales/en.ts
@@ -69,6 +69,10 @@ export const en: LocaleDict = {
       displayName: "Allow All Code Execution",
       subtitle: "MASTER SWITCH: Overrides all other settings to enable ALL execution tools.",
     },
+    protectedPaths: {
+      displayName: "Protected Paths",
+      subtitle: "List of drives or paths to block all operations on (e.g. D:\\, C:\\Windows). One per line.",
+    },
 
     searchApiKey: {
       displayName: "Search API Key",

--- a/src/locales/types.ts
+++ b/src/locales/types.ts
@@ -24,6 +24,7 @@ export interface LocaleDict {
     allowDatabaseInspection: { displayName: string; subtitle: string };
     allowSystemNotifications: { displayName: string; subtitle: string };
     allowAllCode: { displayName: string; subtitle: string };
+    protectedPaths: { displayName: string; subtitle: string };
 
     searchApiKey: { displayName: string; subtitle: string };
     embeddingModel: { displayName: string; subtitle: string };

--- a/src/locales/zh-CN.ts
+++ b/src/locales/zh-CN.ts
@@ -74,6 +74,11 @@ export const zhCN: LocaleDict = {
       subtitle:
         "🔴 主开关：覆盖上述各项设置，一键启用所有代码/命令执行工具。",
     },
+    protectedPaths: {
+      displayName: "受保护路径",
+      subtitle:
+        "要禁止所有操作的盘符或路径列表（例如 D:\\、C:\\Windows）。每行一个。",
+    },
     searchApiKey: {
       displayName: "搜索 API 密钥",
       subtitle:

--- a/src/locales/zh-TW.ts
+++ b/src/locales/zh-TW.ts
@@ -62,6 +62,10 @@ export const zhTW: LocaleDict = {
       displayName: "允許所有程式碼執行",
       subtitle: "主開關：覆蓋所有其他設定，啟用全部執行工具。",
     },
+    protectedPaths: {
+      displayName: "受保護路徑",
+      subtitle: "要禁止所有操作的磁碟機或路徑列表（例如 D:\\、C:\\Windows）。每行一個。",
+    },
     searchApiKey: {
       displayName: "搜尋 API 金鑰",
       subtitle: "搜尋服務的選用 API 金鑰，可避免速率限制。",

--- a/src/toolsProvider.ts
+++ b/src/toolsProvider.ts
@@ -16,9 +16,35 @@ import { validateToolCall } from "./toolCallValidator";
 import type { Browser, Page } from "puppeteer";
 
 // --- Security Helper ---
+let protectedPathsList: string[] = [];
+
+function setProtectedPaths(configValue: string) {
+  protectedPathsList = configValue
+    .split("\n")
+    .map(p => p.trim().replace(/\/$/, "").toLowerCase())
+    .filter(p => p.length > 0);
+}
+
+function isPathProtected(requestedPath: string): boolean {
+  if (protectedPathsList.length === 0) return false;
+  const lowerPath = requestedPath.toLowerCase();
+  const absolute = resolve("/", lowerPath);
+  for (const protectedPath of protectedPathsList) {
+    const absProtected = resolve("/", protectedPath);
+    if (absolute.startsWith(absProtected)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 function validatePath(baseDir: string, requestedPath: string): string {
   const resolved = resolve(baseDir, requestedPath);
   
+  if (isPathProtected(resolved)) {
+    throw new Error(`Access Denied: Path '${resolved}' is in a protected zone.`);
+  }
+
   // Use relative pathing to ensure the resolved path stays within baseDir
   const rel = relative(baseDir, resolved);
   if (rel.startsWith("..") || isAbsolute(rel)) {
@@ -138,6 +164,8 @@ export const toolsProvider: ToolsProvider = async (ctl) => {
   const enableLocalRag = pluginConfig.get("enableLocalRag");
   const enableSecondary = pluginConfig.get("enableSecondaryAgent");
   const embeddingModelName = pluginConfig.get("embeddingModel");
+  const protectedPaths = pluginConfig.get("protectedPaths") as string || "";
+  setProtectedPaths(protectedPaths);
   // const searchApiKey = pluginConfig.get("searchApiKey"); // Used inside tool
 
   // Master override
@@ -833,6 +861,14 @@ export const toolsProvider: ToolsProvider = async (ctl) => {
   tools.push(readFileTool);
 
   const originalExecuteCommandImplementation = async ({ command, input, timeout_seconds }: { command: string; input?: string; timeout_seconds?: number }) => {
+    if (protectedPathsList.length > 0) {
+      const cmdLower = command.toLowerCase();
+      for (const pp of protectedPathsList) {
+        if (cmdLower.includes(pp)) {
+          return { stdout: "", stderr: `Command blocked: '${command}' references protected path '${pp}'.` };
+        }
+      }
+    }
     const childProcess = spawn(command, [], {
       cwd: currentWorkingDirectory,
       shell: true,


### PR DESCRIPTION
Implements the feature requested in #71.

Adds a new 'Protected Paths' config field where users can list drive letters or paths to block from ALL operations (read, write, delete, execute commands, etc.). The protection is checked in validatePath() and in execute_command.

Changes:
- New config field 'protectedPaths' in plugin settings
- isPathProtected() helper that checks any path against the blocked list
- validatePath() now rejects protected paths before workspace boundary check
- execute_command() scans command text for protected path references
- Translations: EN, zh-CN, zh-TW, de

Typecheck: zero errors